### PR TITLE
Update dragger.rs to support fast mouse traveling

### DIFF
--- a/examples/dragger.rs
+++ b/examples/dragger.rs
@@ -1,58 +1,72 @@
 extern crate azul;
-
+ 
 use azul::prelude::*;
-
+ 
 #[derive(Default)]
 struct DragMeApp {
     width: Option<f32>,
+    is_dragging: bool,
 }
-
+ 
 type Event<'a> = WindowEvent<'a, DragMeApp>;
 type State = AppState<DragMeApp>;
-
+ 
 impl Layout for DragMeApp {
     fn layout(&self, _: WindowInfo<DragMeApp>) -> Dom<Self> {
-
+ 
         let mut left = Dom::new(NodeType::Div).with_id("blue");
-
+ 
         // Set the width of the dragger on the red element
         if let Some(w) = self.width {
             left.add_css_override("drag_width", ParsedCssProperty::Width(LayoutWidth::px(w)));
         }
-
+ 
         let right = Dom::new(NodeType::Div).with_id("orange");
-
+ 
         // The dragger is 0px wide, but has an absolutely positioned rectangle
         // inside of it, which can be dragged
         let dragger = Dom::new(NodeType::Div).with_id("dragger").with_child(
             Dom::new(NodeType::Div).with_id("dragger_handle")
-            .with_callback(On::MouseOver, Callback(drag)));
-
+            .with_callback(On::MouseDown, Callback(start_drag)));
+ 
         Dom::new(NodeType::Div).with_id("container")
+            .with_callback(On::MouseOver, Callback(update_drag))
+            .with_callback(On::MouseUp, Callback(stop_drag))
             .with_child(left)
             .with_child(dragger)
             .with_child(right)
     }
 }
-
-fn drag(app: &mut State, event: Event) -> UpdateScreen {
-    let mouse_state = app.windows[event.window].state.get_mouse_state();
-    if mouse_state.left_down {
+ 
+fn start_drag(state: &mut State, _event: Event) -> UpdateScreen {
+    state.data.modify(|data| data.is_dragging = true);
+    UpdateScreen::DontRedraw
+}
+ 
+fn stop_drag(state: &mut State, _event: Event) -> UpdateScreen {
+    state.data.modify(|data| data.is_dragging = false);
+    UpdateScreen::Redraw
+}
+ 
+fn update_drag(state: &mut State, event: Event) -> UpdateScreen {
+    let mouse_state = state.windows[event.window].state.get_mouse_state();
+    if state.data.lock().unwrap().is_dragging {
         let cursor_pos = mouse_state.cursor_pos.unwrap_or(LogicalPosition::new(0.0, 0.0));
-        app.data.modify(|state| state.width = Some(cursor_pos.x as f32));
+        state.data.modify(|data| data.width = Some(cursor_pos.x as f32));
         UpdateScreen::Redraw
     } else {
         UpdateScreen::DontRedraw
     }
 }
+ 
 fn main() {
     macro_rules! CSS_PATH { () => (concat!(env!("CARGO_MANIFEST_DIR"), "/examples/dragger.css")) }
-
+ 
     #[cfg(debug_assertions)]
     let css = Css::hot_reload(CSS_PATH!()).unwrap();
     #[cfg(not(debug_assertions))]
     let css = Css::new_from_str(include_str!(CSS_PATH!())).unwrap();
-
+ 
     let app = App::new(DragMeApp::default(), AppConfig::default());
     app.run(Window::new(WindowCreateOptions::default(), css).unwrap()).unwrap();
 }


### PR DESCRIPTION
Based on the suggestions made by TimTom(discord) to avoid loosing the draggable object by moving the mouse to fast by following the mouse cursor after dragging is activated by mouseup and drop it after mousedown to avoid the problems hit testing introduced in the original example.